### PR TITLE
Add a `getContainerHeight` option

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -667,6 +667,10 @@ function Calendar_constructor(element, overrides) {
 	
 	
 	function _calcSize() { // assumes elementVisible
+		if (typeof options.getContainerHeight === 'function') {
+			suggestedViewHeight = options.getContainerHeight() - (headerElement ? headerElement.outerHeight(true) : 0);
+			return;
+		}
 		if (typeof options.contentHeight === 'number') { // exists and not 'auto'
 			suggestedViewHeight = options.contentHeight;
 		}


### PR DESCRIPTION
this makes it a lot easier to size the control to its container. for example, implementations could do `return container_el.clientHeight`
